### PR TITLE
fix: Contest 等样式

### DIFF
--- a/contest/quiz/templates/base.html
+++ b/contest/quiz/templates/base.html
@@ -145,7 +145,7 @@
         </main>
       {% endblock main %}
       <!-- Footer -->
-      <footer class="mt-4 pt-2 bg-white shadow-inner">
+      <footer class="mt-4 pt-2 bg-gray-50 shadow-inner">
         <div class="flex gap-2 justify-center p-2">
           <img src="{% static 'img/bit-icon.svg' %}" alt="" class="h-8">
           <img src="{% static 'img/bit-text.svg' %}" alt="北京理工大学" class="h-8">

--- a/contest/quiz/templates/contest.html
+++ b/contest/quiz/templates/contest.html
@@ -10,14 +10,15 @@
   {{ constants.DEADLINE_DURATION.seconds | json_script:"data:deadline-duration" }}
 {% endblock scripts %}
 {% block main %}
-  <main>
+  {# aside 与 header 右对齐 #}
+  <main class="mx-auto max-w-7xl w-full">
     {# 进度 #}
     <aside class="sticky top-0 md:top-4 mt-4 md:w-80 md:float-right p-2 bg-white shadow">
-      <div class="grid grid-cols-[auto_1fr] items-center">
+      <div class="grid grid-cols-[auto_1fr] mx-auto max-w-md items-center">
         <div>
           时间：还剩<span id="time-progress-text">{{ constants.DEADLINE_DURATION | natural_delta }}</span>
         </div>
-        <div class="ml-4 h-2 flex flex-auto rounded-full bg-white"
+        <div class="ml-4 h-2 flex flex-auto rounded-full bg-gray-100"
              aria-hidden="true">
           <div id="time-progress-bar"
                class="h-2 w-0 flex-none rounded-l-full rounded-r-[1px] bg-indigo-600"></div>
@@ -26,7 +27,7 @@
         <div>
           作答：还剩<span id="contest-progress-text">{{ constants.N_QUESTIONS_PER_RESPONSE }}</span>题
         </div>
-        <div class="ml-4 h-2 flex flex-auto rounded-full bg-white"
+        <div class="ml-4 h-2 flex flex-auto rounded-full bg-gray-100"
              aria-hidden="true">
           <div id="contest-progress-bar"
                class="h-2 w-0 flex-none rounded-l-full rounded-r-[1px] bg-green-600"></div>

--- a/contest/quiz/templates/contest.html
+++ b/contest/quiz/templates/contest.html
@@ -10,10 +10,10 @@
   {{ constants.DEADLINE_DURATION.seconds | json_script:"data:deadline-duration" }}
 {% endblock scripts %}
 {% block main %}
-  {# aside 与 header 右对齐 #}
+  {# 宽度超过 7xl / 80rem / 1280px 后，aside 与 header 右对齐 #}
   <main class="mx-auto max-w-7xl w-full">
     {# 进度 #}
-    <aside class="sticky top-0 md:top-4 mt-4 md:w-80 md:float-right p-2 bg-white shadow">
+    <aside class="sticky top-0 md:top-4 mt-4 md:mr-4 min-[1280px]:mr-0 md:ml-auto md:w-80 p-2 bg-white shadow">
       <div class="grid grid-cols-[auto_1fr] mx-auto max-w-md items-center">
         <div>
           时间：还剩<span id="time-progress-text">{{ constants.DEADLINE_DURATION | natural_delta }}</span>
@@ -36,34 +36,32 @@
       </div>
     </aside>
     {# 题目 #}
-    <article class="mx-auto max-w-2xl py-6 px-4 sm:px-6 lg:px-8">
-      <div class="prose">
-        <form action="{% url 'quiz:contest_submit' %}" method="post">
-          {% csrf_token %}
-          {% for a in draft_response.answer_set.all %}
-            <fieldset class="my-4 disabled:text-gray-400"
-                      {% if draft_response.outdated %}disabled{% endif %}>
-              <p class="text-lg">
-                <span class="enabled:text-gray-600">{{ forloop.counter }}.</span>
-                <legend class="inline font-bold">{{ a.question }}</legend>
-              </p>
-              {% for choice in a.question.choice_set.all %}
-                <label class="block hover:bg-red-100 my-2">
-                  <input type="radio"
-                         name="question-{{ a.question.id }}"
-                         value="choice-{{ choice.id }}"
-                         {% if a.choice.id == choice.id %}checked{% endif %}>
-                  {{ choice }}
-                </label>
-              {% endfor %}
-            </fieldset>
-          {% endfor %}
-          <div class="text-center">
-            <button type="submit"
-                    class="px-4 py-2 bg-red-700 text-white shadow rounded-full hover:bg-red-500">提交</button>
-          </div>
-        </form>
-      </div>
+    <article class="mx-auto max-w-2xl pb-6 prose">
+      <form action="{% url 'quiz:contest_submit' %}" method="post">
+        {% csrf_token %}
+        {% for a in draft_response.answer_set.all %}
+          <fieldset class="my-4 px-4 sm:px-6 lg:px-8 bg-white shadow disabled:text-gray-400"
+                    {% if draft_response.outdated %}disabled{% endif %}>
+            <p class="text-lg">
+              <span class="enabled:text-gray-600">{{ forloop.counter }}.</span>
+              <legend class="inline font-bold">{{ a.question }}</legend>
+            </p>
+            {% for choice in a.question.choice_set.all %}
+              <label class="block hover:bg-red-100 my-2">
+                <input type="radio"
+                       name="question-{{ a.question.id }}"
+                       value="choice-{{ choice.id }}"
+                       {% if a.choice.id == choice.id %}checked{% endif %}>
+                {{ choice }}
+              </label>
+            {% endfor %}
+          </fieldset>
+        {% endfor %}
+        <div class="text-center">
+          <button type="submit"
+                  class="px-4 py-2 bg-red-700 text-white shadow rounded-full hover:bg-red-500">提交</button>
+        </div>
+      </form>
     </article>
   </main>
 {% endblock main %}

--- a/contest/quiz/templates/contest.html
+++ b/contest/quiz/templates/contest.html
@@ -43,7 +43,10 @@
           {% for a in draft_response.answer_set.all %}
             <fieldset class="my-4 disabled:text-gray-400"
                       {% if draft_response.outdated %}disabled{% endif %}>
-              <legend class="text-lg font-bold">{{ a.question }}</legend>
+              <p class="text-lg">
+                <span class="enabled:text-gray-600">{{ forloop.counter }}.</span>
+                <legend class="inline font-bold">{{ a.question }}</legend>
+              </p>
               {% for choice in a.question.choice_set.all %}
                 <label class="block hover:bg-red-100 my-2">
                   <input type="radio"

--- a/contest/quiz/templates/index.html
+++ b/contest/quiz/templates/index.html
@@ -34,9 +34,7 @@
           <p class="mt-6 text-lg leading-8 text-gray-500">
             由系统随机抽取{{ constants.N_QUESTIONS_PER_RESPONSE }}道题，限时{{ constants.DEADLINE_DURATION | natural_delta }}。每人限答{{ constants.MAX_TRIES }}次。
           </p>
-          <p class="text-lg leading-8 text-red-700 font-bold">
-            由于网络原因，请尽量在时间截止前手动交卷，并推荐使用电脑端进行作答。另外建议不要多开答题页面，否则只有某一页面的答卷有效，可能出现随机性。
-          </p>
+          <p class="text-lg leading-8 text-red-700 font-bold">由于网络原因，请尽量在时间截止前手动交卷。另外建议不要多开答题页面，否则只有某一页面的答卷有效，可能出现随机性。</p>
           <p class="text-lg leading-8 text-gray-500">希望同学们掌握好答题时间，并做好充分的答题准备，预祝同学们考个好成绩！</p>
           <div class="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">
             {% if not user.is_authenticated or status == 'taking contest' or user.student and user.student.n_left_tries > 0 %}

--- a/contest/quiz/templates/index.html
+++ b/contest/quiz/templates/index.html
@@ -26,16 +26,16 @@
         </svg>
         {# Left/top: Texts #}
         <div class="mx-auto max-w-md px-6 text-center lg:mx-0 lg:flex-auto lg:py-16 lg:text-left">
-          <h2 class="text-3xl font-bold tracking-tight sm:text-4xl">
+          <h1 class="text-3xl font-bold tracking-tight sm:text-4xl">
             <span class="text-2xl sm:text-3xl">北京理工大学</span>
             <br>
             国防知识竞赛
-          </h2>
-          <p class="mt-6 text-lg leading-8 text-gray-500">
+          </h1>
+          <p class="mt-6 text-lg leading-8 text-gray-600">
             由系统随机抽取{{ constants.N_QUESTIONS_PER_RESPONSE }}道题，限时{{ constants.DEADLINE_DURATION | natural_delta }}。每人限答{{ constants.MAX_TRIES }}次。
           </p>
           <p class="text-lg leading-8 text-red-700 font-bold">由于网络原因，请尽量在时间截止前手动交卷。另外建议不要多开答题页面，否则只有某一页面的答卷有效，可能出现随机性。</p>
-          <p class="text-lg leading-8 text-gray-500">希望同学们掌握好答题时间，并做好充分的答题准备，预祝同学们考个好成绩！</p>
+          <p class="text-lg leading-8 text-gray-600">希望同学们掌握好答题时间，并做好充分的答题准备，预祝同学们考个好成绩！</p>
           <div class="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">
             {% if not user.is_authenticated or status == 'taking contest' or user.student and user.student.n_left_tries > 0 %}
               {# 不确定 or 正在答题 or 还能发卷 ⇒ 显示 #}


### PR DESCRIPTION
- 进度条背景色未能显示最大进度
- `md`以下，进度条可能超长
- 宽于7xl / `80rem` / `1280px`时，`<aside>`与`<header>`右对齐
- 不特别推荐使用电脑端
- [可访问性](https://wave.webaim.org)
- 正文背景框／题目分割线（二合一了）
- 题号

Resolves #64