### PR TITLE
feat: 选择题和判断题在组卷时分别处理

### DIFF
--- a/contest/quiz/admin.py
+++ b/contest/quiz/admin.py
@@ -22,8 +22,10 @@ class ChoiceInline(admin.TabularInline):
 
 @admin.register(Question)
 class QuestionAdmin(admin.ModelAdmin):
-    fields = ["content"]
+    fields = ["content", "category"]
     inlines = [ChoiceInline]
+    list_filter = ["category"]
+    list_display = ["content", "category"]
     search_fields = ["content"]
 
 

--- a/contest/quiz/constants.py
+++ b/contest/quiz/constants.py
@@ -1,6 +1,8 @@
 """常量
 
 视图、模板中的所有常量。
+
+为避免循环`import`，本模块尽量不引用其它模块。
 """
 from dataclasses import dataclass
 from datetime import timedelta
@@ -41,8 +43,6 @@ class ConstantsNamespace:
     """每套题各题型题数
 
     `quiz.models.Question.Category` ⇒ `int`，未列出的题型不出现。
-
-    为避免循环`import`，用`value`替代`Category`。
     """
 
     SCORE = {
@@ -51,9 +51,7 @@ class ConstantsNamespace:
     }
     """每种题目的分值
 
-    `quiz.models.Question.Category` ⇒ `float`，且覆盖所有`Category`
-
-    为避免循环`import`，用`value`替代`Category`。
+    `quiz.models.Question.Category` ⇒ `float`，且覆盖所有`Category`。
     """
 
     DEADLINE_DURATION = timedelta(minutes=15)

--- a/contest/quiz/constants.py
+++ b/contest/quiz/constants.py
@@ -34,11 +34,30 @@ class ConstantsNamespace:
     为了避免修改，使用 dataclass 而非 dict。
     """
 
+    N_QUESTIONS_PER_RESPONSE = {
+        "B": 5,
+        "R": 5,
+    }
+    """每套题各题型题数
+
+    `quiz.models.Question.Category` ⇒ `int`，未列出的题型不出现。
+
+    为避免循环`import`，用`value`替代`Category`。
+    """
+
+    SCORE = {
+        "B": 8,
+        "R": 12,
+    }
+    """每种题目的分值
+
+    `quiz.models.Question.Category` ⇒ `float`，且覆盖所有`Category`
+
+    为避免循环`import`，用`value`替代`Category`。
+    """
+
     DEADLINE_DURATION = timedelta(minutes=15)
     """作答限时"""
-
-    N_QUESTIONS_PER_RESPONSE = 10
-    """每套题的题数"""
 
     MAX_TRIES = 3
     """答题次数上限"""
@@ -46,14 +65,24 @@ class ConstantsNamespace:
     YEAR = 2023
     MONTH = 9
 
-    SCORE = 100
-    """一套题的总分"""
-
     ROUTES = {
         "quiz:index": PageMeta(title="主页", login_required=False),
         "quiz:contest": PageMeta(title="答题", login_required=True, reluctant=True),
         "quiz:info": PageMeta(title="个人中心", login_required=True),
     }
+
+    @property
+    def n_questions_per_response_total(self) -> int:
+        """每套题总题数"""
+        return sum(self.N_QUESTIONS_PER_RESPONSE.values())
+
+    @property
+    def score_total(self) -> float:
+        """每套题总分"""
+        return sum(
+            self.SCORE[category] * n_questions
+            for category, n_questions in self.N_QUESTIONS_PER_RESPONSE.items()
+        )
 
 
 constants = ConstantsNamespace()

--- a/contest/quiz/migrations/0012_question_category.py
+++ b/contest/quiz/migrations/0012_question_category.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("quiz", "0011_alter_answer_choice_alter_draftanswer_response_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="question",
+            name="category",
+            field=models.CharField(
+                choices=[("R", "单项选择"), ("B", "判断")],
+                default="R",
+                max_length=1,
+                verbose_name="类型",
+            ),
+            preserve_default=False,
+        ),
+    ]

--- a/contest/quiz/models.py
+++ b/contest/quiz/models.py
@@ -34,6 +34,10 @@ class Question(models.Model):
     def __str__(self) -> str:
         return f"{self.content}（{self.Category(self.category).label}）"
 
+    @admin.display(description="分值")
+    def score(self) -> float:
+        return constants.SCORE[self.category]
+
     @classmethod
     def check(cls, **kwargs) -> list[checks.CheckMessage]:
         errors = super().check(**kwargs)
@@ -125,11 +129,7 @@ class Response(models.Model):
     @admin.display(description="得分")
     def score(self) -> float:
         # 未选择、错误不计分，正确计分
-        return sum(
-            score
-            * len(self.answer_set.filter(question__category=category, choice__correct=True))
-            for category, score in constants.SCORE.items()
-        )
+        return sum(a.question.score() for a in self.answer_set.filter(choice__correct=True))
 
 
 class Answer(models.Model):

--- a/contest/quiz/templates/contest.html
+++ b/contest/quiz/templates/contest.html
@@ -25,7 +25,7 @@
           <div class="-my-[0.3125rem] ml-0.5 h-[1.125rem] w-1 rounded-full bg-indigo-600"></div>
         </div>
         <div>
-          作答：还剩<span id="contest-progress-text">{{ constants.N_QUESTIONS_PER_RESPONSE }}</span>题
+          作答：还剩<span id="contest-progress-text">{{ constants.n_questions_per_response_total }}</span>题
         </div>
         <div class="ml-4 h-2 flex flex-auto rounded-full bg-gray-100"
              aria-hidden="true">
@@ -44,7 +44,9 @@
                     {% if draft_response.outdated %}disabled{% endif %}>
             <p class="text-lg">
               <span class="enabled:text-gray-600">{{ forloop.counter }}.</span>
-              <legend class="inline font-bold">{{ a.question }}</legend>
+              <legend class="inline font-bold">
+                {{ a.question.content }}（{# todo constants.SCORE[a.question.category] | as_score #}）
+              </legend>
             </p>
             {% for choice in a.question.choice_set.all %}
               <label class="block hover:bg-red-100 my-2">
@@ -52,7 +54,7 @@
                        name="question-{{ a.question.id }}"
                        value="choice-{{ choice.id }}"
                        {% if a.choice.id == choice.id %}checked{% endif %}>
-                {{ choice }}
+                {{ choice.content }}
               </label>
             {% endfor %}
           </fieldset>

--- a/contest/quiz/templates/contest.html
+++ b/contest/quiz/templates/contest.html
@@ -44,8 +44,9 @@
                     {% if draft_response.outdated %}disabled{% endif %}>
             <p class="text-lg">
               <span class="enabled:text-gray-600">{{ forloop.counter }}.</span>
-              <legend class="inline font-bold">
-                {{ a.question.content }}（{# todo constants.SCORE[a.question.category] | as_score #}）
+              <legend class="inline">
+                <span class="font-bold">{{ a.question.content }}</span>
+                <span class="enabled:text-gray-600">（{{ a.question.score | as_score }}分）</span>
               </legend>
             </p>
             {% for choice in a.question.choice_set.all %}

--- a/contest/quiz/templates/index.html
+++ b/contest/quiz/templates/index.html
@@ -32,7 +32,7 @@
             国防知识竞赛
           </h1>
           <p class="mt-6 text-lg leading-8 text-gray-600">
-            由系统随机抽取{{ constants.N_QUESTIONS_PER_RESPONSE }}道题，限时{{ constants.DEADLINE_DURATION | natural_delta }}。每人限答{{ constants.MAX_TRIES }}次。
+            由系统随机抽取{{ constants.n_questions_per_response_total }}道题，限时{{ constants.DEADLINE_DURATION | natural_delta }}。每人限答{{ constants.MAX_TRIES }}次。
           </p>
           <p class="text-lg leading-8 text-red-700 font-bold">由于网络原因，请尽量在时间截止前手动交卷。另外建议不要多开答题页面，否则只有某一页面的答卷有效，可能出现随机性。</p>
           <p class="text-lg leading-8 text-gray-600">希望同学们掌握好答题时间，并做好充分的答题准备，预祝同学们考个好成绩！</p>

--- a/contest/quiz/templates/info.html
+++ b/contest/quiz/templates/info.html
@@ -11,7 +11,7 @@
     <p class="text-center font-bold mb-2">
       <span class="text-6xl">{{ user.student.final_score | as_score }}</span><span class="text-4xl">分</span>
     </p>
-    <p>满分{{ constants.SCORE }}分，取最高分。</p>
+    <p>满分{{ constants.score_total }}分，取最高分。</p>
     {% with n_left_tries=user.student.n_left_tries %}
       <p>
         {% if n_left_tries > 0 %}

--- a/contest/quiz/tests.py
+++ b/contest/quiz/tests.py
@@ -136,7 +136,7 @@ class ScoreTests(TestCase):
                 for q in questions
             ]
         )
-        self.assertEqual(response.score(), constants.score_total)
+        self.assertEqual(response.score(cache=False), constants.score_total)
 
 
 class ContestViewTests(TestCase):

--- a/contest/quiz/tests.py
+++ b/contest/quiz/tests.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http import HTTPStatus
-from itertools import count, cycle
+from itertools import cycle
 
 from django.http import HttpRequest
 from django.shortcuts import render
@@ -19,6 +19,7 @@ from .models import (
     Student,
     User,
 )
+from .views import select_questions
 
 
 class ResponseModelTests(TestCase):
@@ -73,6 +74,71 @@ class BaseViewTests(TestCase):
         render(HttpRequest(), "base.html")
 
 
+class ScoreTests(TestCase):
+    """答卷分数"""
+
+    def setUp(self):
+        """初始化"""
+        self.user = User.objects.create_user(username="Misato")
+        self.student = Student.objects.create(user=self.user)
+
+        # 制造一张卷子够用的题目，每题首个选项正确
+        # https://wiki.evageeks.org/Main_Page
+        contents_map = {
+            "Characters": [
+                "Shinji Ikari",
+                "Rei Ayanami",
+                "Asuka Langley Soryu",
+                "Misato Katsuragi",
+                "Ritsuko Akagi",
+                "Gendo Ikari",
+            ],
+            "Evangelions": [
+                "Evangelion Unit-00",
+                "Evangelion Unit-01",
+                "Evangelion Unit-02",
+            ],
+            "Angels": [
+                "Adam",
+                "Sachiel",
+                "Gaghiel",
+                "Lilith",
+                "Zeruel",
+                "Tabris",
+            ],
+        }
+        pool = cycle(contents_map.items())
+        for category, n_question in constants.N_QUESTIONS_PER_RESPONSE.items():
+            for _ in range(n_question):
+                question, choices = next(pool)
+                q = Question.objects.create(content=question, category=category)
+                Choice.objects.bulk_create(
+                    [
+                        Choice(content=c, correct=i == 0, question=q)
+                        for i, c in enumerate(choices)
+                    ]
+                )
+
+    def test_select_questions(self):
+        """组卷符合要求"""
+        questions = select_questions()
+        for category, n_question in constants.N_QUESTIONS_PER_RESPONSE.items():
+            self.assertEqual(len([q for q in questions if q.category == category]), n_question)
+
+    def test_full_score(self):
+        """全对答卷得满分"""
+        questions = select_questions()
+
+        response = Response.objects.create(submit_at=timezone.now(), student=self.student)
+        Answer.objects.bulk_create(
+            [
+                Answer(response=response, question=q, choice=q.choice_set.all()[0])
+                for q in questions
+            ]
+        )
+        self.assertEqual(response.score(), constants.score_total)
+
+
 class ContestViewTests(TestCase):
     """竞赛等视图"""
 
@@ -100,15 +166,18 @@ class ContestViewTests(TestCase):
                 "The New Kid ~ Emergency",
             ],
         }
-        questions_count = count()
-        for question, choices in cycle(contents_map.items()):
-            if next(questions_count) >= constants.N_QUESTIONS_PER_RESPONSE:
-                break
-
-            q = Question.objects.create(content=question)
-            Choice.objects.bulk_create(
-                [Choice(content=c, correct=bool(i), question=q) for i, c in enumerate(choices)]
-            )
+        pool = cycle(contents_map.items())
+        for category, n_question in constants.N_QUESTIONS_PER_RESPONSE.items():
+            # `ScoreTests`已测试临界情形，这里换一下，每类题多准备几道
+            for _ in range(n_question + 3):
+                question, choices = next(pool)
+                q = Question.objects.create(content=question, category=category)
+                Choice.objects.bulk_create(
+                    [
+                        Choice(content=c, correct=bool(i), question=q)
+                        for i, c in enumerate(choices)
+                    ]
+                )
 
         self.user = User.objects.create_user(username="Shinji")
         self.student = Student.objects.create(user=self.user)

--- a/contest/quiz/views.py
+++ b/contest/quiz/views.py
@@ -105,6 +105,18 @@ class InfoView(LoginRequiredMixin, IndexView):
     template_name = "info.html"
 
 
+def select_questions() -> list[Question]:
+    """选题组卷"""
+    questions = []
+
+    for category, n_questions in constants.N_QUESTIONS_PER_RESPONSE.items():
+        questions.extend(
+            sample(list(Question.objects.filter(category=category)), k=n_questions)
+        )
+
+    return questions
+
+
 @login_required
 @student_only
 @require_GET
@@ -135,7 +147,7 @@ def contest(request: AuthenticatedHttpRequest) -> HttpResponse:
         )
 
         # Randomly select some questions
-        questions = sample(list(Question.objects.all()), k=constants.N_QUESTIONS_PER_RESPONSE)
+        questions = select_questions()
         # 题目不够时，会抛出异常
         # 因此必须先选题再保存，不然可能保存空的 DraftResponse
 

--- a/doc/models.md
+++ b/doc/models.md
@@ -28,6 +28,7 @@ erDiagram
 
     Question {
         str content
+        str category
     }
     Choice {
         str content

--- a/scripts/convert_problems_csv.py
+++ b/scripts/convert_problems_csv.py
@@ -49,14 +49,8 @@ data: deque[dict] = deque()
 with src_file.open(encoding="utf-8") as f:
     reader = DictReader(f)
     for row in reader:
+        # Convert
         question_pk = pk_shift + int(row["id"])
-        data.append(
-            {
-                "model": "quiz.question",
-                "pk": question_pk,
-                "fields": {"content": row["description"]},
-            }
-        )
 
         if row["choices"] in ["NULL", ""]:  # 判断题
             if row["type"] != "0":
@@ -65,15 +59,29 @@ with src_file.open(encoding="utf-8") as f:
                     f"“{row['description']}” → “{row['choices']}”",
                     stacklevel=1,
                 )
+            category = "B"
             choices = ["正确", "错误"]
-        else:  # 选择题
+        else:  # 单项选择题
             if row["type"] != "1":
                 warn(
-                    "type 和 choies 不一致，将当作选择题："
+                    "type 和 choies 不一致，将当作单项选择题："
                     f"“{row['description']}” → “{row['choices']}”",
                     stacklevel=1,
                 )
+            category = "R"
             choices = row["choices"].split("||")
+
+        # Save
+        data.append(
+            {
+                "model": "quiz.question",
+                "pk": question_pk,
+                "fields": {
+                    "content": row["description"],
+                    "category": category,
+                },
+            }
+        )
 
         for i, c in enumerate(choices):
             data.append(


### PR DESCRIPTION
Refactor:

- `Question`增加`category`字段。
- `constants`的`N_QUESTIONS_PER_RESPONSE`、`SCORE`改为记每种`Category`的情况，另设方法计算总量。
- 选题组卷独立为`select_questions`。

Fix:

- 模板不再隐式调用`__str__`，而取`constant`。

Feature:

- 缓存`response.score()`。

Resolves #75